### PR TITLE
Fixes to LBMR, incl. plotting and schedulling bugs

### DIFF
--- a/LBMR.R
+++ b/LBMR.R
@@ -145,7 +145,7 @@ defineModule(sim, list(
                  desc = "function to add/update species attributes in species cohort table"),
     expectsInput("updateSpeciesEcoregionAttributes", "function",
                  desc = "function to add/update species ecoregion attributes in species cohort table"),
-    expectsInput("spinUpCache", "logical", ""),
+    # expectsInput("spinUpCache", "logical", ""),
     expectsInput("speciesEstablishmentProbMap", "RasterBrick", "Species establishment probability as a RasterBrick, one layer for each species")
   ),
   outputObjects = bind_rows(
@@ -183,7 +183,7 @@ defineModule(sim, list(
                   desc = "a table that has species traits such as longevity..."),
     createsOutput("speciesEcoregion", "data.table",
                   desc = "define the maxANPP, maxB and SEP change with both ecoregion and simulation time"),
-    createsOutput("spinUpCache", "logical", desc = ""),
+    # createsOutput("spinUpCache", "logical", desc = ""),
     createsOutput("spinupOutput", "data.table", desc = ""),
     createsOutput("summaryBySpecies", "data.table", desc = "The average biomass in a pixel, by species"),
     createsOutput("summaryBySpecies1", "data.table", desc = "Pixel summaries by species used for plotting and reporting.")


### PR DESCRIPTION
Fixes include:
* plotting window size issues - now solved by checking window size and plotting map and summay plots separately
* scheduling of `summaryRegen` is no longer depended on plotting time - this event is needed for saving, even if plotting is turned off
* simulated biomass raster file names for saving
* some code cleaning, and clarification of messages and metadata descriptions 