### PR TITLE
don't renumber years in speciesEcoregion

### DIFF
--- a/Biomass_core.R
+++ b/Biomass_core.R
@@ -1001,14 +1001,31 @@ Init <- function(sim, verbose = getOption("LandR.verbose", TRUE)) {
                                           doAssertion = getOption("LandR.assertions", TRUE))
 
   sim$lastReg <- 0
-  speciesEcoregion[, identifier := year > P(sim)$successionTimestep]
-  speciesEcoregion_True <- speciesEcoregion[identifier == TRUE, ]
-  speciesEcoregion_False <- speciesEcoregion[identifier == FALSE, ]
-  if (NROW(speciesEcoregion_False)) {
-    speciesEcoregion_True_addon <- speciesEcoregion_False[year == max(year), ]
-    speciesEcoregion_True <- rbindlist(list(speciesEcoregion_True_addon, speciesEcoregion_True))
+
+  ## the code below makes sure the first year of traits is used even if it's < successionTimestep
+  ## if all(year == start(sim)), all become 0, which is ok because only the most recent
+  ## year of trait data up time(sim) is used (so if all year == 0, year 0's traits
+  ## are used during the first growth event). HOWEVER, this will be problematic if
+  ## speciesEcoregion contains projected values for the entire simulation as only the last
+  ## year of values would be used since all become lower than time(sim)
+
+  # speciesEcoregion[, identifier := year > P(sim)$successionTimestep]
+  # speciesEcoregion_True <- speciesEcoregion[identifier == TRUE, ]
+  # speciesEcoregion_False <- speciesEcoregion[identifier == FALSE, ]
+  # if (NROW(speciesEcoregion_False)) {
+  #   speciesEcoregion_True_addon <- speciesEcoregion_False[year == max(year), ]
+  #   speciesEcoregion_True <- rbindlist(list(speciesEcoregion_True_addon, speciesEcoregion_True))
+  # }
+  # sim$speciesEcoregion <- speciesEcoregion_True[, ':='(year = year - min(year), identifier = NULL)]
+
+  ## proposed fix: check that year 0 exists and if not, add it -- LANDIS-II doc requires a year 0 to be present
+  if (!any(speciesEcoregion$year == 0)) {
+    message("Could not find 'year == 0' in 'speciesEcoregion' table.")
+    message("Using the first year of trait values as 'year 0'")
+    firstYrSppEcoregion <- sim$speciesEcoregion[year == min(year)]
+    firstYrSppEcoregion$year <- 0L
+    sim$speciesEcoregion <- rbind(firstYrSppEcoregion, sim$speciesEcoregion)
   }
-  sim$speciesEcoregion <- speciesEcoregion_True[, ':='(year = year - min(year), identifier = NULL)]
 
   sim$lastFireYear <- "noFire"
 


### PR DESCRIPTION
At the start of `Biomass_core`, there is a chunk of code that renumbers the years in `speciesEcoregion` so that they start at 0. This chunk has two components. The first checks whether there are any years <= `successionTimestep` and takes the last available. The it binds traits for this year with any traits for years > `successionTimestep` and renumbers all years as `year - min(year)`:
```
  speciesEcoregion[, identifier := year > P(sim)$successionTimestep]
  speciesEcoregion_True <- speciesEcoregion[identifier == TRUE, ]
  speciesEcoregion_False <- speciesEcoregion[identifier == FALSE, ]
  if (NROW(speciesEcoregion_False)) {
    speciesEcoregion_True_addon <- speciesEcoregion_False[year == max(year), ]
    speciesEcoregion_True <- rbindlist(list(speciesEcoregion_True_addon, speciesEcoregion_True))
  }
  sim$speciesEcoregion <- speciesEcoregion_True[, ':='(year = year - min(year), identifier = NULL)]
```

I believe this can be problematic when the user/another module provides a table of trait values for different years for several reasons:

Assuming that  `speciesEcoregion` starts with trait values for every year of the simulation:
1. if `start(sim)` and `end(sim)` are both <= `successionTimestep`, then only the last year of trait values will be used.
2. if `start(sim)` and `end(sim)` are both > `successionTimestep`, years in `speciesEcoregion` will be renumbered from 0 to  `end(sim)-start(sim)` and later on, no trait values will be found at `time(sim)`
3. if `start(sim)` is <= `successionTimestep` and `end(sim)` > `successionTimestep`, the trait values used at `start(sim)`  will correspond to whatever year closest to `successionTimestep` in the range [`start(sim)`, `successionTimestep`) and the remaining years in `speciesEcoregion` will be subtracted this year, meaning that the trait values used at each year will be shifted "backwards"

According to the LANDIS-II documentation, `speciesEcoregion` should have values for year 0 , which is presumably why this "year rescaling" is happening -- although I couldn't find a place where we use `speciesEcoregion[, year == 0]` (but I may have missed it). So I propose that, instead of renumbering the years in this table, we check for trait values at `year == 0 ` and if they don't exist we take the trait values at `min(year)` and "duplicate them" for `year == 0`.

Could others please have a look and see if I missed anything?
